### PR TITLE
Add custom nginx container for embedding custom config parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Simply run this command from the root of the cloned repo:
 
 this will take a while.
 
+### Building nginx
+This will embed an optimized configuration for serving Nextcloud files and PHP-FPM resources. Run this
+command from the root of the cloned repo:
+
+`docker compose build nginx`
+
 ### Installing Nextcloud
 
 Run `docker compose up -d`. If something doesn't work try debugging it yourself of open an issue with the php-fpm and nginx logs attached.
@@ -81,9 +87,6 @@ Edit `/your/nextcloud/root/nextcloud/config/config.php` and add the following op
     'timeout' => 0.0,
 ),
 ```
-
-### Editing nginx.conf
-You may also have to replace `example.com` with your own domain or multiple domains in the nginx.conf file.
 
 ### Enabling system cron (optional)
 Nextcloud must perform background tasks. The best way to do that is to use cron. However, on docker this is not easily doable. Here the host will perform the cronjobs required.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,17 @@ services:
 
   nginx:
     container_name: nginx-nextcloud
-    image: nginx:latest
+    build: ./nginx
     ports:
       - 80:80
       - 443:443
     volumes:
       - ${NEXTCLOUD_DIR}:/var/www/html
       - ${DATA_DIR}:/data
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    environment:
+      - NEXTCLOUD_PHP_FPM_HOST=${NEXTCLOUD_PHP_FPM_HOST}
+      - NEXTCLOUD_DOMAIN=${NEXTCLOUD_DOMAIN}
+      - NEXTCLOUD_MAX_UPLOAD_SIZE=${NEXTCLOUD_MAX_UPLOAD_SIZE}
     networks:
       - nextcloud
     depends_on:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,10 @@
+FROM docker.io/library/nginx:latest
+
+ENV NEXTCLOUD_DOMAIN=example.com
+ENV NEXTCLOUD_PHP_FPM_HOST=php-fpm-nextcloud:9000
+ENV NEXTCLOUD_MAX_UPLOAD_SIZE=512M
+
+ADD nginx.conf.template /nginx.conf.template
+ADD docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT ["sh", "-c", "/docker-entrypoint.sh"]

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#/usr/bin/env bash
+
+# This implementation is adapted from the solution proposed here:
+# https://stackoverflow.com/questions/21866477/nginx-use-environment-variables
+
+# envsubst will take the input and replace all references to environment
+# variables with their corresponding value. Because nginx uses the same
+# '$' prefix for its internal variables, we should explicitly define the
+# variables we want to replace rather than replacing all env vars.
+envsubst '
+$NEXTCLOUD_PHP_FPM_HOST
+$NEXTCLOUD_DOMAIN
+$NEXTCLOUD_MAX_UPLOAD_SIZE
+' < /nginx.conf.template > /etc/nginx/nginx.conf
+
+exec nginx -g 'daemon off;'

--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -2,7 +2,7 @@ events { worker_connections 1024; }
 http {
 
     upstream php-handler {
-        server php-fpm-nextcloud:9000;
+        server ${NEXTCLOUD_PHP_FPM_HOST};
         #server unix:/run/php/php8.2-fpm.sock;
     }
 
@@ -16,7 +16,7 @@ http {
         listen 80;
         listen [::]:80;
         # INFO: Set this to your domain
-        server_name example.com;
+        server_name ${NEXTCLOUD_DOMAIN};
 
         # Prevent nginx HTTP Server Detection
         server_tokens off;
@@ -34,7 +34,7 @@ http {
         add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload" always;
 
         # set max upload size and increase upload timeout:
-        client_max_body_size 512M;
+        client_max_body_size ${NEXTCLOUD_MAX_UPLOAD_SIZE};
         client_body_timeout 300s;
         fastcgi_buffers 64 4K;
 


### PR DESCRIPTION
This change adds a locally built Nginx container that uses [`envsubst`](https://www.man7.org/linux/man-pages/man1/envsubst.1.html) to dynamically replace parameters in the `nginx.conf` on container startup. This lets users [put their config in the environment](https://12factor.net/config) and removes the need to mount the `nginx.conf` into the container at runtime.

I'm working on testing this setup now, but assuming it works I'd love to merge it. I so appreciate you working out the php-fpm configuration and cannot wait to convert my main NC install away from AIO!